### PR TITLE
Ensure Teams bot sends only document summaries

### DIFF
--- a/bot-teams/app.py
+++ b/bot-teams/app.py
@@ -101,9 +101,6 @@ class TeamsSimpleBot(ActivityHandler):
                             kind = (res.get("type") or "doc")
                             summary = (res.get("summary") or "")[:2000]  # borne de sécurité
                             await turn_context.send_activity(f"— Document {i} ({kind}):\n{summary}")
-                            text = (res.get("text") or "")
-                            if text:
-                                await turn_context.send_activity(text[:2000])
                 else:
                     await turn_context.send_activity(f"❌ Erreur analyze {r.status_code}")
             except Exception as e:


### PR DESCRIPTION
## Summary
- avoid sending full text in TeamsSimpleBot.on_event_activity
- keep only document summary in Teams responses

## Testing
- `pytest`
- `python -m py_compile bot-teams/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b78efdc98c8320896a9ae6ae915a73