### PR TITLE
feat: add custom chat interface

### DIFF
--- a/interface/custom.css
+++ b/interface/custom.css
@@ -1,0 +1,73 @@
+body {
+  font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  margin: 0;
+}
+
+#messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+  background: #f5f5f5;
+}
+
+.message {
+  max-width: 60%;
+  margin-bottom: 8px;
+  padding: 8px 12px;
+  border-radius: 16px;
+}
+
+.message.user {
+  background: #0078d4;
+  color: #fff;
+  margin-left: auto;
+}
+
+.message.bot {
+  background: #e1e1e1;
+  color: #000;
+  margin-right: auto;
+}
+
+#composer {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  background: #fff;
+  border-top: 1px solid #ccc;
+}
+
+#composer textarea {
+  flex: 1;
+  resize: none;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  padding: 8px;
+  margin-right: 8px;
+}
+
+#composer button {
+  border: none;
+  background: #0078d4;
+  color: #fff;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
+}
+
+#upload-label {
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+#upload-label input {
+  display: none;
+}
+
+#upload-icon {
+  font-size: 24px;
+}

--- a/interface/custom.html
+++ b/interface/custom.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Custom Chat</title>
+  <link rel="stylesheet" href="custom.css" />
+  <script src="https://unpkg.com/botframework-directlinejs/dist/directline.js"></script>
+</head>
+<body>
+  <div id="messages"></div>
+  <div id="composer">
+    <textarea id="input" placeholder="Type a message"></textarea>
+    <label id="upload-label">
+      <input type="file" id="file-input" />
+      <span id="upload-icon">📎</span>
+    </label>
+    <button id="send">➤</button>
+  </div>
+  <script src="custom.js"></script>
+</body>
+</html>

--- a/interface/custom.js
+++ b/interface/custom.js
@@ -1,0 +1,53 @@
+(async function () {
+  const res = await fetch('/api/token');
+  const { token } = await res.json();
+  const dl = new BotFrameworkDirectLine.DirectLine({ token });
+
+  const messages = document.getElementById('messages');
+  const input = document.getElementById('input');
+  const fileInput = document.getElementById('file-input');
+  const sendBtn = document.getElementById('send');
+
+  function appendMessage(text, from) {
+    const div = document.createElement('div');
+    div.className = `message ${from}`;
+    div.textContent = text;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  dl.activity$.subscribe(activity => {
+    if (activity.type === 'message' && activity.from && activity.from.id !== 'user') {
+      appendMessage(activity.text, 'bot');
+    }
+  });
+
+  sendBtn.addEventListener('click', async () => {
+    const text = input.value.trim();
+    if (fileInput.files.length > 0) {
+      const file = fileInput.files[0];
+      const sasRes = await fetch(`/api/upload?name=${encodeURIComponent(file.name)}`);
+      const { uploadUrl, blobUrl } = await sasRes.json();
+      await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'x-ms-blob-type': 'BlockBlob' },
+        body: file
+      });
+      await dl.postActivity({
+        from: { id: 'user' },
+        type: 'event',
+        name: 'files_uploaded',
+        value: { url: blobUrl, name: file.name }
+      }).toPromise();
+      fileInput.value = '';
+    } else if (text) {
+      appendMessage(text, 'user');
+      await dl.postActivity({
+        from: { id: 'user' },
+        type: 'message',
+        text
+      }).toPromise();
+      input.value = '';
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- create custom chat page with messaging and file upload
- connect through Direct Line and show responses in bubbles

## Testing
- `node --check interface/custom.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b793ec028483208edd810022aac732