### PR TITLE
Avoid backend call for empty messages

### DIFF
--- a/bot-teams/app.py
+++ b/bot-teams/app.py
@@ -49,6 +49,10 @@ class TeamsSimpleBot(ActivityHandler):
         user_message = (turn_context.activity.text or "").strip()
         log.info("Message utilisateur: %s", user_message)
 
+        if not user_message:
+            await turn_context.send_activity("Aucun texte reçu.")
+            return
+
         try:
             if not FUNCTION_APP_URL:
                 raise RuntimeError("FUNCTION_APP_URL manquant")


### PR DESCRIPTION
## Summary
- Prevent backend call when user sends empty message and notify user

## Testing
- `python -m py_compile bot-teams/app.py`
- `pytest -q`
- `python - <<'PY'
import os, asyncio, sys
sys.path.append('bot-teams')
os.environ['FUNCTION_APP_URL']='http://httpbin.org/status/400'
from types import SimpleNamespace
import app

bot = app.TeamsSimpleBot()

class DummyContext:
    def __init__(self):
        self.activity = SimpleNamespace(text="")
    async def send_activity(self, message):
        print('sent:', message)

async def main():
    ctx = DummyContext()
    await bot.on_message_activity(ctx)

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b8e77ac5a48320877e40a34e574d65