### PR TITLE
Handle attachment-only messages in Teams bot

### DIFF
--- a/bot-teams/app.py
+++ b/bot-teams/app.py
@@ -49,7 +49,7 @@ class TeamsSimpleBot(ActivityHandler):
         user_message = (turn_context.activity.text or "").strip()
         log.info("Message utilisateur: %s", user_message)
 
-        if not user_message:
+        if not user_message and not turn_context.activity.attachments:
             await turn_context.send_activity("Aucun texte reçu.")
             return
 


### PR DESCRIPTION
## Summary
- Ensure bot only sends "Aucun texte reçu." when both text and attachments are missing
- Confirm event flow triggers analyze API when only attachments are sent

## Testing
- `python - <<'PY'` (manual script to simulate attachment-only message and event)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8edf476c083209c6561fbab5b3135