### PR TITLE
Skip backend call when message empty

### DIFF
--- a/bot-teams/app.py
+++ b/bot-teams/app.py
@@ -53,21 +53,22 @@ class TeamsSimpleBot(ActivityHandler):
             await turn_context.send_activity("Aucun texte reçu.")
             return
 
-        try:
-            if not FUNCTION_APP_URL:
-                raise RuntimeError("FUNCTION_APP_URL manquant")
-            resp = requests.post(
-                FUNCTION_APP_URL,
-                json={"message": user_message},
-                timeout=30,
-            )
-            resp.raise_for_status()
-            response = resp.json().get("response", "Aucune réponse du modèle.")
-        except Exception as e:
-            log.exception("Erreur lors de l'appel backend (chat): %s", e)
-            response = f"Erreur backend : {e}"
+        if user_message:
+            try:
+                if not FUNCTION_APP_URL:
+                    raise RuntimeError("FUNCTION_APP_URL manquant")
+                resp = requests.post(
+                    FUNCTION_APP_URL,
+                    json={"message": user_message},
+                    timeout=30,
+                )
+                resp.raise_for_status()
+                response = resp.json().get("response", "Aucune réponse du modèle.")
+            except Exception as e:
+                log.exception("Erreur lors de l'appel backend (chat): %s", e)
+                response = f"Erreur backend : {e}"
 
-        await turn_context.send_activity(response)
+            await turn_context.send_activity(response)
 
     # AJOUT : handler des events (fichiers envoyés depuis l'interface web)
     async def on_event_activity(self, turn_context: TurnContext):


### PR DESCRIPTION
## Summary
- avoid backend calls when user message is empty

## Testing
- `python -m py_compile bot-teams/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8f161018c832089042e74f7808907