### PR TITLE
Aggregate chat text with file analysis

### DIFF
--- a/interface/index.html
+++ b/interface/index.html
@@ -67,6 +67,7 @@
     const sas = await sasResp.json();
 
     const blobs = [];
+    const userText = store.getState().sendBox.value.trim();
     for (let i = 0; i < sas.uploads.length; i++) {
       const f = fileList[i];
       const u = sas.uploads[i];
@@ -86,7 +87,7 @@
       type: 'event',
       name: 'files_uploaded',
       from: { id: userID },
-      value: { blobs }
+      value: { blobs, userText }
     }).subscribe({
       next: () => { upStatus.textContent = 'Fichiers envoyés pour analyse.'; },
       error: (e) => { console.error(e); upStatus.textContent = '❌ Envoi event échoué.'; }


### PR DESCRIPTION
## Summary
- send uploaded-file events with any typed text from web chat
- buffer user text when attachments are present and defer chat API call
- analyze attachments and combine summaries with user text for single model response

## Testing
- `python -m py_compile bot-teams/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8f4ba35848320993829fbf27c57e1